### PR TITLE
Use bold color instead of white for common information

### DIFF
--- a/forecast/print.go
+++ b/forecast/print.go
@@ -149,7 +149,7 @@ func getBearingDetails(degrees float64) string {
 func printCommon(weather Weather, unitsFormat UnitMeasures) error {
 	if weather.Humidity > 0 {
 
-		humidity := colorstring.Color(fmt.Sprintf("[white]%.2f%s", weather.Humidity*100, "%"))
+		humidity := colorstring.Color(fmt.Sprintf("[bold]%.2f%s", weather.Humidity*100, "%"))
 
 		if weather.Humidity > 0.20 {
 			fmt.Printf("  Ick! The humidity is %s\n", humidity)
@@ -159,39 +159,39 @@ func printCommon(weather Weather, unitsFormat UnitMeasures) error {
 	}
 
 	if weather.PrecipIntensity > 0 {
-		precInt := colorstring.Color(fmt.Sprintf("[white]%.1f %s", weather.PrecipIntensity, unitsFormat.Precipitation))
-		fmt.Printf("  The precipitation intensity of %s is %s\n", colorstring.Color("[white]"+weather.PrecipType), precInt)
+		precInt := colorstring.Color(fmt.Sprintf("[bold]%.1f %s", weather.PrecipIntensity, unitsFormat.Precipitation))
+		fmt.Printf("  The precipitation intensity of %s is %s\n", colorstring.Color("[bold]"+weather.PrecipType), precInt)
 	}
 
 	if weather.PrecipProbability > 0 {
-		prec := colorstring.Color(fmt.Sprintf("[white]%.0f%s", weather.PrecipProbability*100, "%"))
+		prec := colorstring.Color(fmt.Sprintf("[bold]%.0f%s", weather.PrecipProbability*100, "%"))
 		fmt.Printf("  The precipitation probability is %s\n", prec)
 	}
 
 	if weather.NearestStormDistance > 0 {
-		dist := colorstring.Color(fmt.Sprintf("[white]%.1f %s %v", weather.NearestStormDistance, unitsFormat.Length, getBearingDetails(weather.NearestStormBearing)))
+		dist := colorstring.Color(fmt.Sprintf("[bold]%.1f %s %v", weather.NearestStormDistance, unitsFormat.Length, getBearingDetails(weather.NearestStormBearing)))
 		fmt.Printf("  The nearest storm is %s away\n", dist)
 	}
 
 	if weather.WindSpeed > 0 {
-		wind := colorstring.Color(fmt.Sprintf("[white]%.2f %s %v", weather.WindSpeed, unitsFormat.Speed, getBearingDetails(weather.WindBearing)))
+		wind := colorstring.Color(fmt.Sprintf("[bold]%.2f %s %v", weather.WindSpeed, unitsFormat.Speed, getBearingDetails(weather.WindBearing)))
 		fmt.Printf("  The wind speed is %s\n", wind)
 	}
 
 	if weather.CloudCover > 0 {
 
-		cloudCover := colorstring.Color(fmt.Sprintf("[white]%.2f%s", weather.CloudCover*100, "%"))
+		cloudCover := colorstring.Color(fmt.Sprintf("[bold]%.2f%s", weather.CloudCover*100, "%"))
 
 		fmt.Printf("  The cloud coverage is %s\n", cloudCover)
 	}
 
 	if weather.Visibility < 10 {
-		visibility := colorstring.Color(fmt.Sprintf("[white]%.1f %s", weather.Visibility, unitsFormat.Length))
+		visibility := colorstring.Color(fmt.Sprintf("[bold]%.1f %s", weather.Visibility, unitsFormat.Length))
 		fmt.Printf("  The visibility is %s\n", visibility)
 	}
 
 	if weather.Pressure > 0 {
-		pressure := colorstring.Color(fmt.Sprintf("[white]%.1f %s", weather.Pressure, "mbar"))
+		pressure := colorstring.Color(fmt.Sprintf("[bold]%.1f %s", weather.Pressure, "mbar"))
 		fmt.Printf("  The pressure is %s\n\n", pressure)
 	}
 


### PR DESCRIPTION
In a terminal with black on white color scheme the common information was not visible before as they where printed with a white color. Instead use the default foreground color with the bold attribute to highlight the values.

fixes #15

#### Before
![before](https://user-images.githubusercontent.com/516296/43835991-3202b54a-9b14-11e8-912e-c9b4d3307407.png)

#### After 
![after](https://user-images.githubusercontent.com/516296/43835995-3341aa7e-9b14-11e8-97bd-3e724b97eca0.png)


