### PR TITLE
Add snapcraft.yaml to enable building as a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: genuinetools-weather
+version: "0.15.6snap1"
+summary: Weather via the command line
+description: |
+  Uses the darksky.net API so it's super accurate. Also includes any current
+  weather alerts in the output.
+grade: stable
+confinement: strict
+
+apps:
+    genuinetools-weather:
+        command: bin/weather
+        plugs: [ network ]
+parts:
+    weather:
+        source: https://github.com/genuinetools/weather.git
+        source-tag: v0.15.6
+        source-type: git
+        plugin: go
+        go-importpath: github.com/genuinetools/weather
+        after: [go]
+    go:
+        source-tag: go1.7.5


### PR DESCRIPTION
Hi

This PR adds support for building a snap package of weather. Snaps are cross distro Linux software packages. One snap can be installed on Ubuntu all supported LTS and non LTS releases from 14.04 onward. Additionally they can installed on Debian, Manjaro, Fedora, OpenSUSE and others. Making a snap of weather enables you to provide automatic updates on your schedule to your users via the snap store.

If accepted, you can use snapcraft locally, a CI system such as travis or circle-ci, or our free build system (build.snapcraft.io) to create snaps and upload to the store (snapcraft.io/store).

To test this PR locally, I used an Ubuntu 16.04 VM, with the following steps.
```
snap install snapcraft --classic
git clone -b snap https://github.com/dargad/weather
cd weather
snapcraft
```
The generated a .snap file was built from the latest tag (v0.15.6) and can be installed with:

    snap install --dangerous genuinetools-weather_0.15.6snap1_amd64.snap

(the --dangerous is necessary because we’re installing an app which hasn’t gone through the snap store review process)

Once installed the command can be executed:

    genuinetools-weather

Here is some sample output from my tests: https://paste.ubuntu.com/p/q2VfFsswxV/

If landed, you will need to:
- Register an account in the snap store https://snapcraft.io/account
- Register the 'genuinetools-weather' (or simply 'weather') name in the store
  - ```snapcraft login```
  - ```snapcraft register genuinetools-weather```
- Upload a built snap to the store
  - ```snapcraft push genuinetools-weather_0.15.6snap1_amd64.snap --release edge```
- Test installing on a clean Ubuntu 16.04 machine:
  - ```snap install genuinetools-weather --edge```

The store supports multiple risk levels as “channels” with the edge channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally beta and candidate channels can also be used if needed.

Once you are happy, you can push a stable release to the stable channel, update the store page, and promote the application online (we can help there).